### PR TITLE
fix: n100のToolHive関連設定を削除

### DIFF
--- a/NixOS/hosts/lenovo/AI-SERVICES.md
+++ b/NixOS/hosts/lenovo/AI-SERVICES.md
@@ -205,7 +205,7 @@ consumerの追加・変更は`home/agent/agent-services-consumers.nix`だけを�
 hyphen-caseのID、重複しないOAuth client ID・endpoint・vMCP port、正確なcallback URLを
 設定する。callback URLが未確定のconsumerは`enabled = false`のままとし、wildcardや
 別applicationのcallbackを流用しない。consumerを有効化すると、calc-servのKanidm
-client、lenovoのvMCP unitとnginx、n100のnginx locationが同じ定義から生成される。
+clientとlenovoのvMCP unitおよびnginxが同じ定義から生成される。
 
 反映後はlenovoで次を確認する。
 

--- a/NixOS/hosts/n100/nginx.nix
+++ b/NixOS/hosts/n100/nginx.nix
@@ -1,35 +1,8 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:
-let
-  agentServicesConsumers = import ../../home/agent/agent-services-consumers.nix;
-  enabledAgentServicesConsumers = lib.filterAttrs (
-    _: consumer: consumer.enabled
-  ) agentServicesConsumers;
-  agentServicesLocations = lib.listToAttrs (
-    lib.concatMap (consumer: [
-      {
-        name = "= ${consumer.basePath}/mcp";
-        value = {
-          proxyPass = "http://lenovo.sandi05.com:80${consumer.basePath}/mcp";
-          proxyWebsockets = true;
-          extraConfig = ''
-            proxy_buffering off;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-          '';
-        };
-      }
-      {
-        name = "= /.well-known/oauth-protected-resource${consumer.basePath}/mcp";
-        value.proxyPass = "http://lenovo.sandi05.com:80/.well-known/oauth-protected-resource${consumer.basePath}/mcp";
-      }
-    ]) (lib.attrValues enabledAgentServicesConsumers)
-  );
-in
 {
   users.users.nginx.extraGroups = [ "acme" ];
   services.nginx = {
@@ -38,44 +11,6 @@ in
     recommendedTlsSettings = true;
     recommendedGzipSettings = true;
     recommendedProxySettings = true;
-
-    virtualHosts."mcp.sandi05.com-redirect" = {
-      serverName = "mcp.sandi05.com";
-      listen = [
-        {
-          addr = "0.0.0.0";
-          port = 80;
-        }
-        {
-          addr = "[::]";
-          port = 80;
-        }
-      ];
-      extraConfig = ''
-        return 301 https://$host$request_uri;
-      '';
-    };
-
-    virtualHosts."mcp.sandi05.com" = {
-      serverName = "mcp.sandi05.com";
-      listen = [
-        {
-          addr = "0.0.0.0";
-          port = 443;
-          ssl = true;
-        }
-        {
-          addr = "[::]";
-          port = 443;
-          ssl = true;
-        }
-      ];
-      addSSL = true;
-      useACMEHost = "sandi05.com";
-      locations = agentServicesLocations // {
-        "/".return = "404";
-      };
-    };
 
     #---------------------------------------------------------------------
     # Nextcloud
@@ -509,7 +444,6 @@ in
         "stream.sandi05.com"
         "project.sandi05.com"
         "notes.sandi05.com"
-        "mcp.sandi05.com"
         "marginalis.sandi05.com"
       ];
       dnsProvider = "cloudflare";


### PR DESCRIPTION
## 概要

n100に残っていたToolHive・vMCP向けのnginx設定を削除します。

## 主な変更

- consumer定義のimportとnginx location生成処理を削除
- `mcp.sandi05.com`のvirtual hostとHTTPからHTTPSへのredirectを削除
- ACME証明書の追加ドメインから`mcp.sandi05.com`を削除
- 関連文書からn100のnginx locationに関する記述を削除

## 検証

- `nixfmt --check NixOS/hosts/n100/nginx.nix`
- `nix-instantiate --parse NixOS/hosts/n100/nginx.nix`
- `NixOS/hosts/n100`内にToolHive・vMCP・`mcp.sandi05.com`関連参照がないことを確認
- `git diff --check`

## 未実施の検証

`nixos-sandi-n100`の全体評価は、既存の`streaming`入力が参照するGitHubアーカイブでHTTP 404となるため完了できませんでした。