### PR TITLE
fix: CodexによるGitブランチ作成を許可

### DIFF
--- a/NixOS/home/agent/agent-config/codex-commands.rules
+++ b/NixOS/home/agent/agent-config/codex-commands.rules
@@ -25,6 +25,12 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["git", "switch", "-c"],
+    decision = "allow",
+    justification = "新しい作業ブランチの作成を許可する"
+)
+
+prefix_rule(
     pattern = ["cargo", ["build", "check", "clippy", "doc", "fmt", "metadata", "test", "tree"]],
     decision = "allow",
     justification = "Rustの構築・読み取り・検証操作を許可する"


### PR DESCRIPTION
## 概要

Codexが新しい作業ブランチを作成する際に、`git switch -c`の承認要請が生じないようexecpolicy規則を追加します。

## 変更内容

- `git switch -c <branch>`を許可するprefix ruleを追加
- 既存ブランチへ切り替える`git switch <branch>`は許可対象外のまま維持

## 検証

- `codex execpolicy check`で`git switch -c fix/remove-n100-toolhive`が`allow`になることを確認
- `codex execpolicy check`で既存の`git status --short --branch`が`allow`になることを確認
- `git diff --check`