### PR TITLE
config: Codexの承認を自動レビューする

### DIFF
--- a/NixOS/home/agent/agent-config/codex-config.toml
+++ b/NixOS/home/agent/agent-config/codex-config.toml
@@ -1,5 +1,7 @@
 # mcp_oauth_credentials_store = "file"
 
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
 sandbox_mode = "workspace-write"
 
 [agents]


### PR DESCRIPTION
## 概要

Codexでsandbox境界を越える操作が必要になったとき、eligibleな承認要請をreviewer agentへ自動的に回す設定を追加します。

## 変更内容

- `approval_policy = "on-request"`を明示
- `approvals_reviewer = "auto_review"`を有効化
- `sandbox_mode = "workspace-write"`は維持

この設定はsandboxを無効化せず、承認者をユーザーから自動reviewerへ変更します。危険または対象外と判断された操作は、引き続き拒否またはユーザー確認になる場合があります。

## 検証

- `codex --strict-config`で設定キーを検証
- `homeConfigurations.sandbox.activationPackage.drvPath`の評価